### PR TITLE
Inverse alpha

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ Creates a 3x3 image of black and white pixels with varying transparency
 	pixels = dict( ((i, j), colour)
 		for j, row in enumerate(image)
 			for i, colour in enumerate(row))
-	xpm_im = xpm.XpmImage((3, 3), pixels).make_image()
+	# resolution, pixels, invert alpha
+	xpm_im = xpm.XpmImage((3, 3), pixels, False).make_image()
 	# XPM ARGB out
 	if sys.version_info.major >= 3:
 		sys.stdout.buffer.write(xpm_im)

--- a/xpm.py
+++ b/xpm.py
@@ -14,7 +14,7 @@ import string
 COLOUR_DIGITS = bytes((string.digits + string.ascii_lowercase).encode('ascii'))
 
 def pil_save(pil_image, inverse_alpha=False, variable_name=b'picture'):
-    formatter = XpmImage.from_pil(pil_image, inverse_alpha, ariable_name)
+    formatter = XpmImage.from_pil(pil_image, inverse_alpha, variable_name)
     return formatter.make_image()
 
 
@@ -25,7 +25,7 @@ class XpmImage(object):
         transparent_colour = pil_image.info.get('transparency')
         return cls(pil_image.size, pil_image.load(), inverse_alpha, variable_name, transparent_colour)
 
-    def __init__(self, size, pixels, inverse_alpha, variable_name=b'picture', transparent_colour=None):
+    def __init__(self, size, pixels, inverse_alpha=False, variable_name=b'picture', transparent_colour=None):
         "Pixels is a dictionary mapping x,y coordinates to rgba tuples"
         self.xsize, self.ysize = size
         self.inverse_alpha = inverse_alpha
@@ -100,9 +100,12 @@ class XpmImage(object):
         else:
             str = '#'
             if (type(colour) is tuple):
+                colour = list(colour)
                 if (len(colour) == 4):
-                    colour[3] = 255 - colour[3]
+                    if (self.inverse_alpha):
+                        colour[3] = 255 - colour[3]
                     str += '{3:02x}'
+                colour = tuple(colour)
                 for d in range(len(colour) - (len(colour) == 4)):
                     str += '{{{0}:02x}}'.format(d)
                 return str.format(*[c for c in colour])
@@ -144,7 +147,7 @@ if __name__ == '__main__':
     args = PARSER.parse_args()
     image = PIL.Image.open(args.file)
     
-    xpm_bytes = pil_save(image, alpha_inversion=args.inverse_alpha,
+    xpm_bytes = pil_save(image, inverse_alpha=args.inverse_alpha,
         variable_name=args.variable_name.encode('ascii'))
 
     if sys.version_info.major >= 3:


### PR DESCRIPTION
Some programs may interpret 0xFF or 0x00 as transparent or opaque depending if it's a measurement of how transparency or opacity.

Opacity Form Representation:
0xFF is full opaque (meaning full visibility/non-see through)
0x00 is full transparent (meaning no visibility/completely see through)

Transparency Form Representation:
0x00 is full opaque (meaning full visibility/non-see through)
0xFF is full transparent (meaning no visibility/completely see through)

There is now an option to chose if your values are now in opacity-ness or transparency-ness.
When using via python module `python3 -m xpm <file.png> --inverse_alpha` or `-i`.

By default xpm_argb measures in opacity-ness form (so 0xFF is full visible)

When you specific the invert alpha it will measure in transparency-ness form. (so 0x00 is full visible)